### PR TITLE
fix outbound json merge issue

### DIFF
--- a/app/src/main/java/moe/matsuri/nb4a/utils/Util.kt
+++ b/app/src/main/java/moe/matsuri/nb4a/utils/Util.kt
@@ -3,6 +3,7 @@ package moe.matsuri.nb4a.utils
 import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Base64
+import moe.matsuri.nb4a.SingBoxOptions.SingBoxOption
 import java.io.ByteArrayOutputStream
 import java.text.SimpleDateFormat
 import java.util.*
@@ -118,8 +119,12 @@ object Util {
         if (j.isBlank()) return
         val m = JavaUtil.gson.fromJson(j, to.javaClass)
         m.forEach { (k, v) ->
-            if (v is Map<*, *> && to[k] is Map<*, *>) {
-                val currentMap = (to[k] as Map<*, *>).toMutableMap()
+            if (v is Map<*, *>) {
+                val currentMap = when (to[k]) {
+                    is SingBoxOption -> ((to[k] as SingBoxOption).asMap() as Map<*, *>).toMutableMap()
+                    is Map<*, *> -> (to[k] as Map<*, *>).toMutableMap()
+                    else -> mutableMapOf()
+                }
                 currentMap += v
                 to[k] = currentMap
             } else {


### PR DESCRIPTION
当使用自定义出站JSON时，如果currentOutbound中存在相同的key，但value是SingBoxOption类型，这时就不能正确合并。这个PR修复了这个issue