### PR TITLE
fix: customized multiplex JSON cannot be merged to the outbound settings

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
@@ -396,7 +396,7 @@ fun buildConfig(
                                     2 -> "yamux"
                                     else -> "h2mux"
                                 }
-                            }
+                            }.asMap()
                         }
                     }
                 }


### PR DESCRIPTION
在自定义出站JSON中设置multiplex，当出站设置也有multiplex时，两者不能正确merge到一起，这个PR修复此问题