### PR TITLE
fix(shadowsocks): allow set plugin without plugin-opts

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/ui/profile/ShadowsocksSettingsActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/profile/ShadowsocksSettingsActivity.kt
@@ -39,7 +39,7 @@ class ShadowsocksSettingsActivity : ProfileSettingsActivity<ShadowsocksBean>() {
 
         val pn = pluginName.readStringFromCache()
         val pc = pluginConfig.readStringFromCache()
-        plugin = if (pn.isNotBlank() && pc.isNotBlank()) "$pn;$pc" else ""
+        plugin = if (pn.isNotBlank()) "$pn;$pc" else ""
     }
 
     override fun PreferenceFragmentCompat.createPreferences(


### PR DESCRIPTION
https://github.com/SagerNet/sing-box/blob/0f643bf414a5314d003c9f7981de2640a3869b12/transport/sip003/obfs.go#L26-L39

If you don't set mode for obfs-local, sing-box will use default value `http`. So in some cases you needn't set `plugin_opts` in configuration.

This pull request might fix some "airport" users' problem.