### PR TITLE
chore: cancel search when clicking the return button

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/ui/ConfigurationFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/ConfigurationFragment.kt
@@ -147,6 +147,12 @@ class ConfigurationFragment @JvmOverloads constructor(
         if (searchView != null) {
             searchView.setOnQueryTextListener(this)
             searchView.maxWidth = Int.MAX_VALUE
+
+	    searchView.setOnQueryTextFocusChangeListener { _, hasFocus ->
+                if (!hasFocus) {
+                    cancelSearch(searchView)
+                }
+            }
         }
 
         groupPager = view.findViewById(R.id.group_pager)
@@ -1699,6 +1705,11 @@ class ConfigurationFragment @JvmOverloads constructor(
 
                 }
             }
+        }
+
+	private fun cancelSearch(searchView: SearchView) {
+            searchView.onActionViewCollapsed()
+            searchView.clearFocus()
         }
 
 }


### PR DESCRIPTION
Before: 
    If you are searching, when you click the return button, NekoBox will exit.

Now:
    Clicking the return button when searching means cancel searching instead of exit.