### PR TITLE
Fix MTU conflict with mieru plugin

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/Constants.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/Constants.kt
@@ -90,6 +90,7 @@ object Key {
     const val SERVER_ENCRYPTION = "serverEncryption"
     const val SERVER_ALPN = "serverALPN"
     const val SERVER_CERTIFICATES = "serverCertificates"
+    const val SERVER_MTU = "serverMTU"
 
     const val SERVER_CONFIG = "serverConfig"
     const val SERVER_CUSTOM = "serverCustom"

--- a/app/src/main/java/io/nekohasekai/sagernet/bg/proto/BoxInstance.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/bg/proto/BoxInstance.kt
@@ -147,6 +147,7 @@ abstract class BoxInstance(
 
                         val envMap = mutableMapOf<String, String>()
                         envMap["MIERU_CONFIG_JSON_FILE"] = configFile.absolutePath
+                        envMap["MIERU_PROTECT_PATH"] = "protect_path"
 
                         val commands = mutableListOf(
                             initPlugin("mieru-plugin").path, "run",

--- a/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
@@ -189,6 +189,7 @@ object DataStore : OnPreferenceDataStoreChangeListener {
     var serverEncryption by profileCacheStore.string(Key.SERVER_ENCRYPTION)
     var serverALPN by profileCacheStore.string(Key.SERVER_ALPN)
     var serverCertificates by profileCacheStore.string(Key.SERVER_CERTIFICATES)
+    var serverMTU by profileCacheStore.stringToInt(Key.SERVER_MTU)
     var serverHeaders by profileCacheStore.string(Key.SERVER_HEADERS)
     var serverAllowInsecure by profileCacheStore.boolean(Key.SERVER_ALLOW_INSECURE)
 

--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/mieru/MieruFmt.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/mieru/MieruFmt.kt
@@ -47,6 +47,7 @@ fun MieruBean.buildMieruConfig(port: Int): String {
                     put("password", password)
                 })
                 put("servers", serverInfo)
+                put("mtu", mtu)
             })
         })
     }.toStringPretty()

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/profile/MieruSettingsActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/profile/MieruSettingsActivity.kt
@@ -41,7 +41,7 @@ class MieruSettingsActivity : ProfileSettingsActivity<MieruBean>() {
         DataStore.serverProtocol = protocol
         DataStore.serverUsername = username
         DataStore.serverPassword = password
-        DataStore.mtu = mtu
+        DataStore.serverMTU = mtu
     }
 
     override fun MieruBean.serialize() {
@@ -51,7 +51,7 @@ class MieruSettingsActivity : ProfileSettingsActivity<MieruBean>() {
         protocol = DataStore.serverProtocol
         username = DataStore.serverUsername
         password = DataStore.serverPassword
-        mtu = DataStore.mtu
+        mtu = DataStore.serverMTU
     }
 
     override fun PreferenceFragmentCompat.createPreferences(
@@ -66,7 +66,7 @@ class MieruSettingsActivity : ProfileSettingsActivity<MieruBean>() {
             summaryProvider = PasswordSummaryProvider
         }
         val protocol = findPreference<SimpleMenuPreference>(Key.SERVER_PROTOCOL)!!
-        val mtu = findPreference<EditTextPreference>(Key.MTU)!!
+        val mtu = findPreference<EditTextPreference>(Key.SERVER_MTU)!!
         mtu.isVisible = protocol.value.equals("UDP")
         protocol.setOnPreferenceChangeListener { _, newValue ->
             mtu.isVisible = newValue.equals("UDP")

--- a/app/src/main/res/xml/mieru_preferences.xml
+++ b/app/src/main/res/xml/mieru_preferences.xml
@@ -38,7 +38,7 @@
             app:title="@string/password" />
         <EditTextPreference
             app:icon="@drawable/baseline_public_24"
-            app:key="mtu"
+            app:key="serverMTU"
             app:title="@string/mtu"
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>


### PR DESCRIPTION
This bug was reported in https://github.com/enfein/mieru/issues/111.

As shown in app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt, NekoBox has two data stores:

1. configurationStore is used to store global app configuration
2. profileCacheStore is used to store each proxy profile

Previously, MieruSettingsActivity.kt uses `var mtu by configurationStore.stringToInt(Key.MTU)` to store the mieru MTU configuration. This has two problems. First, a mieru setting will override the global MTU configuration used by the VpnService. Second, two mieru settings can override each other.

To fix this, we introduce a new field `var serverMTU by profileCacheStore.stringToInt(Key.SERVER_MTU)` to store the mieru MTU configuration. We confirmed that the APK built from https://github.com/enfein/NekoBoxForAndroid/actions/runs/7550857326 resolved this bug.