### PR TITLE
Rule to bypass TLD country domains

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/database/ProfileManager.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/database/ProfileManager.kt
@@ -236,6 +236,13 @@ object ProfileManager {
                 )
                 createRule(
                     RuleEntity(
+                        name = app.getString(R.string.route_bypass_domain, displayCountry),
+                        domains = "domain:$country",
+                        outbound = -1
+                    ), false
+                )
+                createRule(
+                    RuleEntity(
                         name = app.getString(R.string.route_bypass_ip, displayCountry),
                         ip = "geoip:$country",
                         outbound = -1


### PR DESCRIPTION
`geoip:ru` and `geosite:ru` may not explicitly cover all `*.ru` domains.
And I'm not sure if this is the right way to add these. Please tell me what you think.