### PR TITLE
fix: Box cannot be reopened after being closed

### DIFF
--- a/libcore/box.go
+++ b/libcore/box.go
@@ -144,6 +144,8 @@ func (b *BoxInstance) Close() (err error) {
 
 	// close box
 	b.Close()
+	// close box.Box
+	b.Box.Close()
 
 	return nil
 }


### PR DESCRIPTION
fix issues #728 #711  and so on: Box failed to shut down properly, resulting in a series of issues such as (Failed:: initialize inbound/direct [dns in]: listen tcp 127.0.0.1:6450: bind: address already in use).