### PR TITLE
fix: donate info for zh-HK and zh-TW

### DIFF
--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -45,7 +45,7 @@
     <string name="auto_connect_summary">在開機或本程式更新後將自動重新啓用代理</string>
     <string name="delete">移除</string>
     <string name="enable">啟用</string>
-    <string name="donate_info">世界好得意 請比世界錢</string>
+    <string name="donate_info">貓貓好得意 請比貓貓錢</string>
     <string name="route_bypass">繞過</string>
     <string name="route_block">封鎖</string>
     <string name="add_profile_methods_scan_qr_code">掃描二維碼</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -284,7 +284,7 @@
     <string name="connection_test_icmp_ping_unavailable">ICMPing 無法使用</string>
     <string name="connection_test_domain_not_found">網域不存在</string>
     <string name="connection_test_refused">連線被拒</string>
-    <string name="donate_info">世界很可愛 請給世界錢</string>
+    <string name="donate_info">貓貓很可愛 請給貓貓錢</string>
     <string name="connection_test_unreachable">無法連線</string>
     <string name="connection_test_timeout">逾時</string>
     <string name="append_http_proxy">為 VPN 附加 HTTP 代理</string>


### PR DESCRIPTION
fix: #872 

本来还想把其他翻译一并更改的，可是zh-TW和zh-CN的顺序不一样，不知道翻译到哪里了，无从入手。还是顺序无关，看见哪个没翻译就在后面加？