### PR TITLE
fix: Certain single-label domain names can only be resolved by `InetAddress.getAllByName()`

### DIFF
--- a/app/src/main/java/moe/matsuri/nb4a/net/LocalResolverImpl.kt
+++ b/app/src/main/java/moe/matsuri/nb4a/net/LocalResolverImpl.kt
@@ -128,11 +128,11 @@ object LocalResolverImpl : LocalDNSTransport {
                 // 老版本系统，继续用阻塞的 InetAddress
                 try {
                     val u = SagerNet.underlyingNetwork
-                    val answer = if (u != null) {
-                        u.getAllByName(domain)
-                    } else {
-                        InetAddress.getAllByName(domain)
-                    }
+                    val answer = try {
+                        u?.getAllByName(domain)
+                    } catch (e: UnknownHostException) {
+                        null
+                    } ?: InetAddress.getAllByName(domain)
                     if (answer != null) {
                         ctx.success(answer.mapNotNull { it.hostAddress }.joinToString("\n"))
                     } else {


### PR DESCRIPTION
I don't quite understand why but apparently some internal, single-label domain names (like `my-router`) can only be resolved by `InetAddress.getAllByName()` but not `Network.getAllByName()`.

`DnsResolver` doesn't have such quirk.