### PR TITLE
feat: add separate home screen shortcuts for VPN enable / disable

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -222,6 +222,24 @@
             </intent-filter>
         </activity>
         <activity
+            android:name="io.nekohasekai.sagernet.ui.QuickEnableShortcut"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:label="@string/quick_enable"
+            android:launchMode="singleTask"
+            android:process=":bg"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+        <activity
+            android:name="io.nekohasekai.sagernet.ui.QuickDisableShortcut"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:label="@string/quick_disable"
+            android:launchMode="singleTask"
+            android:process=":bg"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+        <activity
             android:name="io.nekohasekai.sagernet.ui.AppManagerActivity"
             android:configChanges="uiMode"
             android:excludeFromRecents="true"

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/QuickDisableShortcut.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/QuickDisableShortcut.kt
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *                                                                             *
+ *  Copyright (C) 2017 by Max Lv <max.c.lv@gmail.com>                          *
+ *  Copyright (C) 2017 by Mygod Studio <[Email1]>  *
+ *                                                                             *
+ *  This program is free software: you can redistribute it and/or modify       *
+ *  it under the terms of the GNU General Public License as published by       *
+ *  the Free Software Foundation, either version 3 of the License, or          *
+ *  (at your option) any later version.                                        *
+ *                                                                             *
+ *  This program is distributed in the hope that it will be useful,            *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ *  GNU General Public License for more details.                               *
+ *                                                                             *
+ *  You should have received a copy of the GNU General Public License          *
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+package io.nekohasekai.sagernet.ui
+
+import android.app.Activity
+import android.content.pm.ShortcutManager
+import android.os.Build
+import android.os.Bundle
+import androidx.core.content.getSystemService
+import io.nekohasekai.sagernet.SagerNet
+import io.nekohasekai.sagernet.aidl.ISagerNetService
+import io.nekohasekai.sagernet.bg.BaseService
+import io.nekohasekai.sagernet.bg.SagerConnection
+
+class QuickDisableShortcut : Activity(), SagerConnection.Callback {
+    private val connection = SagerConnection(SagerConnection.CONNECTION_ID_SHORTCUT)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        connection.connect(this, this)
+        if (Build.VERSION.SDK_INT >= 25) {
+            getSystemService<ShortcutManager>()!!.reportShortcutUsed("disable")
+        }
+    }
+
+    override fun onServiceConnected(service: ISagerNetService) {
+        val state = BaseService.State.values()[service.state]
+        if (state.canStop) {
+            SagerNet.stopService()
+        }
+        finish()
+    }
+
+    override fun stateChanged(state: BaseService.State, profileName: String?, msg: String?) {}
+
+    override fun onDestroy() {
+        connection.disconnect(this)
+        super.onDestroy()
+    }
+}

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/QuickEnableShortcut.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/QuickEnableShortcut.kt
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *                                                                             *
+ *  Copyright (C) 2017 by Max Lv <[Email0]>                          *
+ *  Copyright (C) 2017 by Mygod Studio <[Email1]>  *
+ *                                                                             *
+ *  This program is free software: you can redistribute it and/or modify       *
+ *  it under the terms of the GNU General Public License as published by       *
+ *  the Free Software Foundation, either version 3 of the License, or          *
+ *  (at your option) any later version.                                        *
+ *                                                                             *
+ *  This program is distributed in the hope that it will be useful,            *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ *  GNU General Public License for more details.                               *
+ *                                                                             *
+ *  You should have received a copy of the GNU General Public License          *
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+package io.nekohasekai.sagernet.ui
+
+import android.app.Activity
+import android.content.pm.ShortcutManager
+import android.os.Build
+import android.os.Bundle
+import androidx.core.content.getSystemService
+import io.nekohasekai.sagernet.SagerNet
+import io.nekohasekai.sagernet.aidl.ISagerNetService
+import io.nekohasekai.sagernet.bg.BaseService
+import io.nekohasekai.sagernet.bg.SagerConnection
+
+class QuickEnableShortcut : Activity(), SagerConnection.Callback {
+    private val connection = SagerConnection(SagerConnection.CONNECTION_ID_SHORTCUT)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        connection.connect(this, this)
+        if (Build.VERSION.SDK_INT >= 25) {
+            getSystemService<ShortcutManager>()!!.reportShortcutUsed("enable")
+        }
+    }
+
+    override fun onServiceConnected(service: ISagerNetService) {
+        val state = BaseService.State.values()[service.state]
+        if (state == BaseService.State.Stopped) {
+            SagerNet.startService()
+        }
+        finish()
+    }
+
+    override fun stateChanged(state: BaseService.State, profileName: String?, msg: String?) {}
+
+    override fun onDestroy() {
+        connection.disconnect(this)
+        super.onDestroy()
+    }
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -23,6 +23,8 @@
     <string name="group_name">أسم المجموعة</string>
     <string name="tile_title">الجلاد</string>
     <string name="quick_toggle">تبديل</string>
+    <string name="quick_enable">تمكين</string>
+    <string name="quick_disable">تعطيل</string>
     <string name="group_default">غير مجمعة</string>
     <string name="document">وثيقة</string>
     <string name="theme">موضوع</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -100,6 +100,8 @@
     <string name="menu_traffic">Трафік</string>
     <string name="tile_title">Перамыкач</string>
     <string name="quick_toggle">Пераключыць</string>
+    <string name="quick_enable">Уключыць</string>
+    <string name="quick_disable">Выключыць</string>
     <string name="group_default">Разгрупаваны</string>
     <string name="document">Дакумент</string>
     <string name="theme">Тэма</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -5,6 +5,8 @@
     <string name="group_name">Gruppen name</string>
     <string name="tile_title">Umschalter</string>
     <string name="quick_toggle">Umschalten</string>
+    <string name="quick_enable">Aktivieren</string>
+    <string name="quick_disable">Deaktivieren</string>
     <string name="group_default">Ungruppiert</string>
     <string name="document">Dokument</string>
     <string name="theme">Style</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -14,7 +14,9 @@
     <string name="theme">Tema</string> 
     <string name="document">Documento</string> 
     <string name="group_default">Desagrupado</string> 
-    <string name="quick_toggle">Alternar</string> 
+    <string name="quick_toggle">Alternar</string>
+    <string name="quick_enable">Habilitar</string>
+    <string name="quick_disable">Deshabilitar</string>
     <string name="tile_title">Conmutador</string> 
     <string name="menu_traffic">Tráfico</string> 
     <!-- externel --> 

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -17,6 +17,8 @@
     <string name="document">مستندات</string>
     <string name="group_default">گروه پیش‌فرض</string>
     <string name="quick_toggle">تغییر وضعیت</string>
+    <string name="quick_enable">فعال‌سازی</string>
+    <string name="quick_disable">غیرفعال‌سازی</string>
     <string name="tile_title">سوییچر</string>
     <string name="menu_traffic">ترافیک</string>
     <string name="menu_dashboard">sing-box تنظیمات</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -57,6 +57,8 @@
     <string name="group_update">Mettre à jour</string>
     <string name="group_name">Nom du groupe</string>
     <string name="quick_toggle">Basculer</string>
+    <string name="quick_enable">Activer</string>
+    <string name="quick_disable">Désactiver</string>
     <string name="group_default">Dégroupé</string>
     <string name="document">Document</string>
     <string name="theme">Thème</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -83,6 +83,8 @@
     <string name="group_name">Nama grup</string>
     <string name="tile_title">Pengalih</string>
     <string name="quick_toggle">Beralih</string>
+    <string name="quick_enable">Aktifkan</string>
+    <string name="quick_disable">Nonaktifkan</string>
     <string name="group_default">Tidak bergrup</string>
     <string name="document">Dokumen</string>
     <string name="theme">Tema</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -35,6 +35,8 @@
     <string name="group_name">グループ名</string>
     <string name="tile_title">スイッチャー</string>
     <string name="quick_toggle">トグル</string>
+    <string name="quick_enable">有効化</string>
+    <string name="quick_disable">無効化</string>
     <string name="group_default">グループ化されていない</string>
     <string name="document">ドキュメント（英語）</string>
     <string name="theme">テーマ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -9,6 +9,8 @@
     <string name="project">프로젝트</string>
     <string name="app_desc">코틀린에 기록 된 안드로이드에 대한 보편적 인 프록시 도구 체인.</string>
     <string name="quick_toggle">비녀장</string>
+    <string name="quick_enable">활성화</string>
+    <string name="quick_disable">비활성화</string>
     <string name="group_default">그룹 해제</string>
     <string name="document">문서</string>
     <string name="theme">테마</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -319,6 +319,8 @@
     <string name="group_update">Oppdater</string>
     <string name="tile_title">Bytter</string>
     <string name="quick_toggle">Veksle</string>
+    <string name="quick_enable">Aktiver</string>
+    <string name="quick_disable">Deaktiver</string>
     <string name="menu_configuration">Konfigurasjon</string>
     <string name="app_desc">Den universelle proxy -verktøykjeden for Android, skrevet i Kotlin.</string>
     <string name="group_filter">Raffinering</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -342,6 +342,8 @@
 <string name="proxy_cat">Настройки сервера</string>
 <string name="proxy_chain">Прокси-цепочка</string>
 <string name="quick_toggle">Переключить</string>
+<string name="quick_enable">Включить</string>
+<string name="quick_disable">Выключить</string>
 <string name="reboot_required">Не удалось запустить службу VPN. Возможно, вам потребуется перезагрузить устройство.</string>
 <string name="release_wake_lock">Отключить WakeLock</string>
 <string name="remote_dns">Удаленный DNS</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -71,6 +71,8 @@
     <string name="tile_title">Değiştirici</string>
     <string name="group_name">Grup adı</string>
     <string name="quick_toggle">Aç/Kapat</string>
+    <string name="quick_enable">Etkinleştir</string>
+    <string name="quick_disable">Devre Dışı Bırak</string>
     <string name="group_default">Gruplandırılmamış</string>
     <string name="document">Döküman</string>
     <string name="theme">Tema</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -17,6 +17,8 @@
     <string name="document">Документація</string>
     <string name="group_default">Без групи</string>
     <string name="quick_toggle">Перемикач</string>
+    <string name="quick_enable">Увімкнути</string>
+    <string name="quick_disable">Вимкнути</string>
     <string name="tile_title">Перемикач</string>
     <string name="menu_traffic">Трафік</string>
     <string name="menu_dashboard">Панель керування sing-box</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -12,6 +12,8 @@
     <string name="menu_about">关于</string>
     <string name="group_default">未分组</string>
     <string name="quick_toggle">切换</string>
+    <string name="quick_enable">启用</string>
+    <string name="quick_disable">禁用</string>
     <!-- group -->
     <string name="group_name">分组名</string>
     <string name="group_update">更新</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -75,6 +75,8 @@
     <string name="password_opt">密碼（可選）</string>
     <string name="start">開始</string>
     <string name="quick_toggle">切換</string>
+    <string name="quick_enable">啟用</string>
+    <string name="quick_disable">停用</string>
     <string name="group_edit">編輯</string>
     <string name="cag_ws">WebSocket 設定</string>
     <string name="show_direct_speed">顯示直連速度</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -11,6 +11,8 @@
     <string name="menu_group">群組</string>
     <string name="menu_about">關於</string>
     <string name="quick_toggle">切換</string>
+    <string name="quick_enable">啟用</string>
+    <string name="quick_disable">停用</string>
     <!-- group -->
     <string name="group_name">群組名稱</string>
     <string name="group_update">更新</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,8 @@
     <string name="document">Document</string>
     <string name="group_default">Ungrouped</string>
     <string name="quick_toggle">Toggle</string>
+    <string name="quick_enable">Enable</string>
+    <string name="quick_disable">Disable</string>
     <string name="tile_title">Switcher</string>
     <string name="menu_traffic">Traffic</string>
     <string name="menu_dashboard">sing-box Dashboard</string>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -11,6 +11,26 @@
             android:targetPackage="moe.nb4a" />
     </shortcut>
     <shortcut
+        android:icon="@drawable/ic_qu_shadowsocks_launcher"
+        android:shortcutId="enable"
+        android:shortcutLongLabel="@string/quick_enable"
+        android:shortcutShortLabel="@string/quick_enable">
+        <intent
+            android:action="android.intent.action.MAIN"
+            android:targetClass="io.nekohasekai.sagernet.ui.QuickEnableShortcut"
+            android:targetPackage="moe.nb4a" />
+    </shortcut>
+    <shortcut
+        android:icon="@drawable/ic_qu_shadowsocks_launcher"
+        android:shortcutId="disable"
+        android:shortcutLongLabel="@string/quick_disable"
+        android:shortcutShortLabel="@string/quick_disable">
+        <intent
+            android:action="android.intent.action.MAIN"
+            android:targetClass="io.nekohasekai.sagernet.ui.QuickDisableShortcut"
+            android:targetPackage="moe.nb4a" />
+    </shortcut>
+    <shortcut
         android:icon="@drawable/ic_qu_camera_launcher"
         android:shortcutId="scan"
         android:shortcutLongLabel="@string/add_profile_methods_scan_qr_code"


### PR DESCRIPTION
**Description**
This PR adds two new home screen shortcuts:
- Enable VPN — always starts the VPN if it is stopped
- Disable VPN — always stops the VPN if it is running

Previously there was only a toggle shortcut, which is not suitable for automation because the current VPN state must be known in advance.

With these separate shortcuts it becomes possible to reliably integrate NekoBoxForAndroid with automation tools such as Tasker, MacroDroid, Automate, or OEM automation systems (e.g. Samsung Modes & Routines).

**Implementation details**
- Added QuickEnableShortcut and QuickDisableShortcut activities
- Registered them in AndroidManifest.xml
- Added new dynamic shortcuts in res/xml/shortcuts.xml
- Added localized strings quick_enable and quick_disable

No existing behavior is changed; the original toggle shortcut remains available.

**Testing**
Tested on Samsung Galaxy S25 Ultra with Samsung Modes & Routines automation

For convenience, a test build from this fork is available here (self-signed, for testing only):
https://github.com/Slava-Shchipunov/NekoBoxForAndroid/releases/tag/1.4.1-20260115