### PR TITLE
Add toggle control for socks5 proxy and password protection for socks5 outbounds like naive

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/Constants.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/Constants.kt
@@ -40,7 +40,7 @@ object Key {
     const val MIXED_USERNAME = "mixedUsername"
     const val MIXED_PASSWORD = "mixedPassword"
     const val ALLOW_ACCESS = "allowAccess"
-    const val DISABLE_MIXED = "disableMixed"
+    const val ENABLE_MIXED = "enableMixed"
     const val SPEED_INTERVAL = "speedInterval"
     const val SHOW_DIRECT_SPEED = "showDirectSpeed"
 

--- a/app/src/main/java/io/nekohasekai/sagernet/Constants.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/Constants.kt
@@ -40,6 +40,7 @@ object Key {
     const val MIXED_USERNAME = "mixedUsername"
     const val MIXED_PASSWORD = "mixedPassword"
     const val ALLOW_ACCESS = "allowAccess"
+    const val DISABLE_MIXED = "disableMixed"
     const val SPEED_INTERVAL = "speedInterval"
     const val SHOW_DIRECT_SPEED = "showDirectSpeed"
 

--- a/app/src/main/java/io/nekohasekai/sagernet/Constants.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/Constants.kt
@@ -37,6 +37,8 @@ object Key {
     const val BYPASS_LAN_IN_CORE = "bypassLanInCore"
 
     const val MIXED_PORT = "mixedPort"
+    const val MIXED_USERNAME = "mixedUsername"
+    const val MIXED_PASSWORD = "mixedPassword"
     const val ALLOW_ACCESS = "allowAccess"
     const val SPEED_INTERVAL = "speedInterval"
     const val SHOW_DIRECT_SPEED = "showDirectSpeed"

--- a/app/src/main/java/io/nekohasekai/sagernet/bg/proto/BoxInstance.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/bg/proto/BoxInstance.kt
@@ -56,6 +56,8 @@ abstract class BoxInstance(
         buildConfig()
         for ((chain) in config.externalIndex) {
             chain.entries.forEachIndexed { index, (port, profile) ->
+                val creds = config.localProxyCredentials[port] ?: error("No local proxy credentials for port $port")
+                val (localProxyUsername, localProxyPassword) = creds
                 when (val bean = profile.requireBean()) {
                     is TrojanGoBean -> {
                         initPlugin("trojan-go-plugin")
@@ -69,7 +71,7 @@ abstract class BoxInstance(
 
                     is NaiveBean -> {
                         initPlugin("naive-plugin")
-                        pluginConfigs[port] = profile.type to bean.buildNaiveConfig(port)
+                        pluginConfigs[port] = profile.type to bean.buildNaiveConfig(port, localProxyUsername, localProxyPassword)
                     }
 
                     is HysteriaBean -> {

--- a/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
@@ -142,7 +142,7 @@ object DataStore : OnPreferenceDataStoreChangeListener {
         }
     }
 
-    var disableMixed by configurationStore.boolean(Key.DISABLE_MIXED)
+    var enableMixed by configurationStore.boolean(Key.ENABLE_MIXED)
 
     private fun getLocalPort(key: String, default: Int): Int {
         return parsePort(configurationStore.getString(key), default + userIndex)

--- a/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
@@ -142,6 +142,7 @@ object DataStore : OnPreferenceDataStoreChangeListener {
         }
     }
 
+    var disableMixed by configurationStore.boolean(Key.DISABLE_MIXED)
 
     private fun getLocalPort(key: String, default: Int): Int {
         return parsePort(configurationStore.getString(key), default + userIndex)

--- a/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
@@ -20,6 +20,7 @@ import io.nekohasekai.sagernet.ktx.string
 import io.nekohasekai.sagernet.ktx.stringToInt
 import io.nekohasekai.sagernet.ktx.stringToIntIfExists
 import moe.matsuri.nb4a.TempDatabase
+import moe.matsuri.nb4a.utils.Util
 
 object DataStore : OnPreferenceDataStoreChangeListener {
 
@@ -128,10 +129,16 @@ object DataStore : OnPreferenceDataStoreChangeListener {
     var mixedPort: Int
         get() = getLocalPort(Key.MIXED_PORT, 2080)
         set(value) = saveLocalPort(Key.MIXED_PORT, value)
+    var mixedUsername by configurationStore.string(Key.MIXED_USERNAME) { "User" }
+    var mixedPassword by configurationStore.string(Key.MIXED_PASSWORD) { Util.generateCryptoSecurePassword() }
 
     fun initGlobal() {
         if (configurationStore.getString(Key.MIXED_PORT) == null) {
             mixedPort = mixedPort
+        }
+
+        if (configurationStore.getString(Key.MIXED_PASSWORD) == null) {
+            mixedPassword = Util.generateCryptoSecurePassword()
         }
     }
 

--- a/app/src/main/java/io/nekohasekai/sagernet/database/ProxyEntity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/database/ProxyEntity.kt
@@ -288,8 +288,11 @@ data class ProxyEntity(
                             }
 
                             is NaiveBean -> {
+                                val localProxyCredentials = config.localProxyCredentials[port]
+                                val localProxyUsername = localProxyCredentials?.first ?: ""
+                                val localProxyPassword = localProxyCredentials?.second ?: ""
                                 append("\n\n")
-                                append(bean.buildNaiveConfig(port))
+                                append(bean.buildNaiveConfig(port, localProxyUsername, localProxyPassword))
                             }
 
                             is HysteriaBean -> {

--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
@@ -227,7 +227,7 @@ fun buildConfig(
                     }
                 }
             })
-            if (!DataStore.disableMixed) {
+            if (!DataStore.enableMixed) {
                 inbounds.add(Inbound_MixedOptions().apply {
                     type = "mixed"
                     tag = TAG_MIXED

--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
@@ -227,7 +227,7 @@ fun buildConfig(
                     }
                 }
             })
-            if (!DataStore.enableMixed) {
+            if (DataStore.enableMixed) {
                 inbounds.add(Inbound_MixedOptions().apply {
                     type = "mixed"
                     tag = TAG_MIXED

--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
@@ -232,6 +232,12 @@ fun buildConfig(
                 domain_strategy = genDomainStrategy(DataStore.resolveDestination)
                 sniff = needSniff
                 sniff_override_destination = needSniffOverride
+                users = listOf(
+                    User().apply {
+                        username = DataStore.mixedUsername
+                        password = DataStore.mixedPassword
+                    },
+                )
             })
         }
 

--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
@@ -55,6 +55,7 @@ class ConfigBuildResult(
     var trafficMap: Map<String, List<ProxyEntity>>,
     var profileTagMap: Map<Long, String>,
     val selectorGroupId: Long,
+    val localProxyCredentials: Map<Int, Pair<String, String>>,
 ) {
     data class IndexEntity(var chain: LinkedHashMap<Int, ProxyEntity>)
 }
@@ -62,7 +63,8 @@ class ConfigBuildResult(
 fun buildConfig(
     proxy: ProxyEntity, forTest: Boolean = false, forExport: Boolean = false
 ): ConfigBuildResult {
-
+    val localProxyCredentials = HashMap<Int, Pair<String, String>>()
+    
     if (proxy.type == TYPE_CONFIG) {
         val bean = proxy.requireBean() as ConfigBean
         if (bean.type == 0) {
@@ -72,7 +74,8 @@ fun buildConfig(
                 proxy.id, //
                 mapOf(TAG_PROXY to listOf(proxy)), //
                 mapOf(proxy.id to TAG_PROXY), //
-                -1L
+                -1L,
+                localProxyCredentials
             )
         }
     }
@@ -334,11 +337,16 @@ fun buildConfig(
 
                 if (proxyEntity.needExternal()) { // externel outbound
                     val localPort = mkPort()
+                    val localProxyUsername = Util.generateCryptoSecurePassword()
+                    val localProxyPassword = Util.generateCryptoSecurePassword()
                     externalChainMap[localPort] = proxyEntity
+                    localProxyCredentials[localPort] = localProxyUsername to localProxyPassword
                     currentOutbound = Outbound_SocksOptions().apply {
                         type = "socks"
                         server = LOCALHOST
                         server_port = localPort
+                        username = localProxyUsername
+                        password = localProxyPassword
                     }
                 } else {
                     // internal outbound
@@ -756,7 +764,8 @@ fun buildConfig(
             proxy.id,
             trafficMap,
             tagMap,
-            if (buildSelector) group.id else -1L
+            if (buildSelector) group.id else -1L,
+            localProxyCredentials
         )
     }
 

--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
@@ -224,21 +224,23 @@ fun buildConfig(
                     }
                 }
             })
-            inbounds.add(Inbound_MixedOptions().apply {
-                type = "mixed"
-                tag = TAG_MIXED
-                listen = bind
-                listen_port = DataStore.mixedPort
-                domain_strategy = genDomainStrategy(DataStore.resolveDestination)
-                sniff = needSniff
-                sniff_override_destination = needSniffOverride
-                users = listOf(
-                    User().apply {
-                        username = DataStore.mixedUsername
-                        password = DataStore.mixedPassword
-                    },
-                )
-            })
+            if (!DataStore.disableMixed) {
+                inbounds.add(Inbound_MixedOptions().apply {
+                    type = "mixed"
+                    tag = TAG_MIXED
+                    listen = bind
+                    listen_port = DataStore.mixedPort
+                    domain_strategy = genDomainStrategy(DataStore.resolveDestination)
+                    sniff = needSniff
+                    sniff_override_destination = needSniffOverride
+                    users = listOf(
+                        User().apply {
+                            username = DataStore.mixedUsername
+                            password = DataStore.mixedPassword
+                        },
+                    )
+                })
+            }
         }
 
         outbounds = mutableListOf()

--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/naive/NaiveFmt.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/naive/NaiveFmt.kt
@@ -5,6 +5,7 @@ import io.nekohasekai.sagernet.fmt.LOCALHOST
 import io.nekohasekai.sagernet.ktx.*
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.json.JSONObject
+import android.net.Uri
 
 fun parseNaive(link: String): NaiveBean {
     val proto = link.substringAfter("+").substringBefore(":")
@@ -54,7 +55,7 @@ fun NaiveBean.toUri(proxyOnly: Boolean = false): String {
     return builder.toLink(if (proxyOnly) proto else "naive+$proto", false)
 }
 
-fun NaiveBean.buildNaiveConfig(port: Int): String {
+fun NaiveBean.buildNaiveConfig(port: Int, localProxyUsername: String, localProxyPassword: String): String {
     return JSONObject().apply {
         // process ipv6
         finalAddress = finalAddress.wrapIPV6Host()
@@ -75,7 +76,10 @@ fun NaiveBean.buildNaiveConfig(port: Int): String {
             }
         }
 
-        put("listen", "socks://$LOCALHOST:$port")
+        val usernameEnc = Uri.encode(localProxyUsername)
+        val passwordEnc = Uri.encode(localProxyPassword)
+
+        put("listen", "socks://$usernameEnc:$passwordEnc@$LOCALHOST:$port")
         put("proxy", toUri(true))
         if (extraHeaders.isNotBlank()) {
             put("extra-headers", extraHeaders.split("\n").joinToString("\r\n"))

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/SettingsPreferenceFragment.kt
@@ -64,7 +64,7 @@ class SettingsPreferenceFragment : PreferenceFragmentCompat() {
         val mixedPort = findPreference<EditTextPreference>(Key.MIXED_PORT)!!
         val mixedUsername = findPreference<EditTextPreference>(Key.MIXED_USERNAME)!!
         val mixedPassword = findPreference<EditTextPreference>(Key.MIXED_PASSWORD)!!
-        val disableMixed = findPreference<SwitchPreference>(Key.DISABLE_MIXED)!!
+        val enableMixed = findPreference<SwitchPreference>(Key.ENABLE_MIXED)!!
         val serviceMode = findPreference<Preference>(Key.SERVICE_MODE)!!
         val allowAccess = findPreference<Preference>(Key.ALLOW_ACCESS)!!
         val appendHttpProxy = findPreference<SwitchPreference>(Key.APPEND_HTTP_PROXY)!!
@@ -163,9 +163,9 @@ class SettingsPreferenceFragment : PreferenceFragmentCompat() {
             mixedPrefsToToggle.forEach { it?.isEnabled = !disabled }
         }
 
-        updateMixedPrefsState(disableMixed?.isChecked == true)
+        updateMixedPrefsState(enableMixed?.isChecked == true)
 
-        disableMixed?.setOnPreferenceChangeListener { _, newValue ->
+        enableMixed?.setOnPreferenceChangeListener { _, newValue ->
             updateMixedPrefsState(newValue as Boolean)
             needReload()
             true
@@ -174,7 +174,7 @@ class SettingsPreferenceFragment : PreferenceFragmentCompat() {
         mixedPort.onPreferenceChangeListener = reloadListener
         mixedUsername.onPreferenceChangeListener = reloadListener
         mixedPassword.onPreferenceChangeListener = reloadListener
-        //disableMixed.onPreferenceChangeListener = reloadListener
+        //enableMixed.onPreferenceChangeListener = reloadListener
         appendHttpProxy.onPreferenceChangeListener = reloadListener
         showDirectSpeed.onPreferenceChangeListener = reloadListener
         trafficSniffing.onPreferenceChangeListener = reloadListener

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/SettingsPreferenceFragment.kt
@@ -159,8 +159,8 @@ class SettingsPreferenceFragment : PreferenceFragmentCompat() {
             findPreference<Preference>("allowAccess")
         )
 
-        fun updateMixedPrefsState(disabled: Boolean) {
-            mixedPrefsToToggle.forEach { it?.isEnabled = !disabled }
+        fun updateMixedPrefsState(enabled: Boolean) {
+            mixedPrefsToToggle.forEach { it?.isEnabled = enabled }
         }
 
         updateMixedPrefsState(enableMixed?.isChecked == true)

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/SettingsPreferenceFragment.kt
@@ -62,6 +62,8 @@ class SettingsPreferenceFragment : PreferenceFragmentCompat() {
             true
         }
         val mixedPort = findPreference<EditTextPreference>(Key.MIXED_PORT)!!
+        val mixedUsername = findPreference<EditTextPreference>(Key.MIXED_USERNAME)!!
+        val mixedPassword = findPreference<EditTextPreference>(Key.MIXED_PASSWORD)!!
         val serviceMode = findPreference<Preference>(Key.SERVICE_MODE)!!
         val allowAccess = findPreference<Preference>(Key.ALLOW_ACCESS)!!
         val appendHttpProxy = findPreference<SwitchPreference>(Key.APPEND_HTTP_PROXY)!!
@@ -149,6 +151,8 @@ class SettingsPreferenceFragment : PreferenceFragmentCompat() {
         }
 
         mixedPort.onPreferenceChangeListener = reloadListener
+        mixedUsername.onPreferenceChangeListener = reloadListener
+        mixedPassword.onPreferenceChangeListener = reloadListener
         appendHttpProxy.onPreferenceChangeListener = reloadListener
         showDirectSpeed.onPreferenceChangeListener = reloadListener
         trafficSniffing.onPreferenceChangeListener = reloadListener

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/SettingsPreferenceFragment.kt
@@ -64,6 +64,7 @@ class SettingsPreferenceFragment : PreferenceFragmentCompat() {
         val mixedPort = findPreference<EditTextPreference>(Key.MIXED_PORT)!!
         val mixedUsername = findPreference<EditTextPreference>(Key.MIXED_USERNAME)!!
         val mixedPassword = findPreference<EditTextPreference>(Key.MIXED_PASSWORD)!!
+        val disableMixed = findPreference<SwitchPreference>(Key.DISABLE_MIXED)!!
         val serviceMode = findPreference<Preference>(Key.SERVICE_MODE)!!
         val allowAccess = findPreference<Preference>(Key.ALLOW_ACCESS)!!
         val appendHttpProxy = findPreference<SwitchPreference>(Key.APPEND_HTTP_PROXY)!!
@@ -150,9 +151,30 @@ class SettingsPreferenceFragment : PreferenceFragmentCompat() {
             true
         }
 
+        val mixedPrefsToToggle = listOf(
+            findPreference<Preference>("mixedPort"),
+            findPreference<Preference>("mixedUsername"),
+            findPreference<Preference>("mixedPassword"),
+            findPreference<Preference>("appendHttpProxy"),
+            findPreference<Preference>("allowAccess")
+        )
+
+        fun updateMixedPrefsState(disabled: Boolean) {
+            mixedPrefsToToggle.forEach { it?.isEnabled = !disabled }
+        }
+
+        updateMixedPrefsState(disableMixed?.isChecked == true)
+
+        disableMixed?.setOnPreferenceChangeListener { _, newValue ->
+            updateMixedPrefsState(newValue as Boolean)
+            needReload()
+            true
+        }
+
         mixedPort.onPreferenceChangeListener = reloadListener
         mixedUsername.onPreferenceChangeListener = reloadListener
         mixedPassword.onPreferenceChangeListener = reloadListener
+        //disableMixed.onPreferenceChangeListener = reloadListener
         appendHttpProxy.onPreferenceChangeListener = reloadListener
         showDirectSpeed.onPreferenceChangeListener = reloadListener
         trafficSniffing.onPreferenceChangeListener = reloadListener

--- a/app/src/main/java/moe/matsuri/nb4a/utils/Util.kt
+++ b/app/src/main/java/moe/matsuri/nb4a/utils/Util.kt
@@ -197,4 +197,12 @@ object Util {
         val encoded = match?.groupValues?.get(1) ?: ""
         return URLDecoder.decode(encoded, StandardCharsets.UTF_8.name())
     }
+
+    fun generateCryptoSecurePassword(length: Int = 10): String {
+        val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()"
+        val secureRandom = java.security.SecureRandom()
+        return (1..length)
+            .map { chars[secureRandom.nextInt(chars.length)] }
+            .joinToString("")
+    }
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -27,10 +27,10 @@
 <string name="ads">Реклама</string>
 <string name="allow_access">Разрешить подключения из локальной сети</string>
 <string name="allow_access_sum">Привязать входящие серверы к 0.0.0.0</string>
-<string name="proxy_username">Юзернейм прокси</string>
-<string name="proxy_password">Пароль прокси</string>
-<string name="disable_mixed">Отключить прокси SOCKS5</string>
-<string name="disable_mixed_sum">Отключить прокси SOCKS5 для недопущения утечки внешнего IP сервера VPN</string>
+<string name="proxy_username">Логин</string>
+<string name="proxy_password">Пароль</string>
+<string name="ENABLE_MIXED">Включить прокси SOCKS5</string>
+<string name="ENABLE_MIXED_sum">Использование SOCKS5-прокси может раскрыть внешний IP VPN-сервера</string>
 <string name="allow_insecure">Разрешить небезопасное подключение</string>
 <string name="allow_insecure_on_request_sum">Отключить проверку сертификатов при обновлении подписок</string>
 <string name="allow_insecure_sum">Отключить проверку сертификата. При включении эта функция настолько же безопасна как передача пароля в открытом виде</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -27,6 +27,8 @@
 <string name="ads">Реклама</string>
 <string name="allow_access">Разрешить подключения из локальной сети</string>
 <string name="allow_access_sum">Привязать входящие серверы к 0.0.0.0</string>
+<string name="disable_mixed">Отключить прокси SOCKS5</string>
+<string name="disable_mixed_sum">Отключить прокси SOCKS5 для недопущения утечки внешнего IP сервера VPN</string>
 <string name="allow_insecure">Разрешить небезопасное подключение</string>
 <string name="allow_insecure_on_request_sum">Отключить проверку сертификатов при обновлении подписок</string>
 <string name="allow_insecure_sum">Отключить проверку сертификата. При включении эта функция настолько же безопасна как передача пароля в открытом виде</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -27,6 +27,8 @@
 <string name="ads">Реклама</string>
 <string name="allow_access">Разрешить подключения из локальной сети</string>
 <string name="allow_access_sum">Привязать входящие серверы к 0.0.0.0</string>
+<string name="proxy_username">Юзернейм прокси</string>
+<string name="proxy_password">Пароль прокси</string>
 <string name="disable_mixed">Отключить прокси SOCKS5</string>
 <string name="disable_mixed_sum">Отключить прокси SOCKS5 для недопущения утечки внешнего IP сервера VPN</string>
 <string name="allow_insecure">Разрешить небезопасное подключение</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -29,8 +29,8 @@
 <string name="allow_access_sum">Привязать входящие серверы к 0.0.0.0</string>
 <string name="proxy_username">Логин</string>
 <string name="proxy_password">Пароль</string>
-<string name="ENABLE_MIXED">Включить прокси SOCKS5</string>
-<string name="ENABLE_MIXED_sum">Использование SOCKS5-прокси может раскрыть внешний IP VPN-сервера</string>
+<string name="enable_mixed">Включить прокси SOCKS5</string>
+<string name="enable_mixed_sum">Использование прокси SOCKS5 может раскрыть внешний IP VPN-сервера</string>
 <string name="allow_insecure">Разрешить небезопасное подключение</string>
 <string name="allow_insecure_on_request_sum">Отключить проверку сертификатов при обновлении подписок</string>
 <string name="allow_insecure_sum">Отключить проверку сертификата. При включении эта функция настолько же безопасна как передача пароля в открытом виде</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,8 @@
     <string name="cag_route">Route Settings</string>
     <string name="allow_access">Allow Connections from the LAN</string>
     <string name="allow_access_sum">Bind inbound servers to 0.0.0.0</string>
+    <string name="disable_mixed">Disable SOCKS5 proxy</string>
+    <string name="disable_mixed_sum">SOCKS5 proxy can be disabled to prevent VPN server external IP leak</string>
     <string name="inbound_settings">Inbound Settings</string>
     <string name="general_settings">App Settings</string>
     <string name="require_http">Enable HTTP inbound</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,8 +60,8 @@
     <string name="allow_access_sum">Bind inbound servers to 0.0.0.0</string>
     <string name="proxy_username">Username</string>
     <string name="proxy_password">Password</string>
-    <string name="ENABLE_MIXED">Enable SOCKS5 proxy</string>
-    <string name="ENABLE_MIXED_sum">Enabled SOCKS5 proxy may expose the VPN server\'s external IP</string>
+    <string name="enable_mixed">Enable SOCKS5 proxy</string>
+    <string name="enable_mixed_sum">Enabled SOCKS5 proxy may expose the VPN server\'s external IP</string>
     <string name="inbound_settings">Inbound Settings</string>
     <string name="general_settings">App Settings</string>
     <string name="require_http">Enable HTTP inbound</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,8 @@
     <string name="cag_route">Route Settings</string>
     <string name="allow_access">Allow Connections from the LAN</string>
     <string name="allow_access_sum">Bind inbound servers to 0.0.0.0</string>
+    <string name="proxy_username">Proxy Username</string>
+    <string name="proxy_password">Proxy Password</string>
     <string name="disable_mixed">Disable SOCKS5 proxy</string>
     <string name="disable_mixed_sum">SOCKS5 proxy can be disabled to prevent VPN server external IP leak</string>
     <string name="inbound_settings">Inbound Settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,10 +58,10 @@
     <string name="cag_route">Route Settings</string>
     <string name="allow_access">Allow Connections from the LAN</string>
     <string name="allow_access_sum">Bind inbound servers to 0.0.0.0</string>
-    <string name="proxy_username">Proxy Username</string>
-    <string name="proxy_password">Proxy Password</string>
-    <string name="disable_mixed">Disable SOCKS5 proxy</string>
-    <string name="disable_mixed_sum">SOCKS5 proxy can be disabled to prevent VPN server external IP leak</string>
+    <string name="proxy_username">Username</string>
+    <string name="proxy_password">Password</string>
+    <string name="ENABLE_MIXED">Enable SOCKS5 proxy</string>
+    <string name="ENABLE_MIXED_sum">Enabled SOCKS5 proxy may expose the VPN server\'s external IP</string>
     <string name="inbound_settings">Inbound Settings</string>
     <string name="general_settings">App Settings</string>
     <string name="require_http">Enable HTTP inbound</string>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -194,6 +194,16 @@
             app:key="mixedPort"
             app:title="@string/port_proxy"
             app:useSimpleSummaryProvider="true" />
+        <EditTextPreference
+            app:defaultValue="User"
+            app:key="mixedUsername"
+            app:title="Proxy Username"
+            app:useSimpleSummaryProvider="true" />
+        <EditTextPreference
+            app:icon="@drawable/ic_settings_password"
+            app:key="mixedPassword"
+            app:title="Proxy Password"
+            app:useSimpleSummaryProvider="true" />
         <SwitchPreference
             app:defaultValue="false"
             app:key="appendHttpProxy"

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -197,13 +197,13 @@
         <EditTextPreference
             app:defaultValue="User"
             app:key="mixedUsername"
-            app:title="Proxy Username"
-            app:useSimpleSummaryProvider="true" />
+            app:useSimpleSummaryProvider="true"
+            app:title="@string/proxy_username" />
         <EditTextPreference
             app:icon="@drawable/ic_settings_password"
             app:key="mixedPassword"
-            app:title="Proxy Password"
-            app:useSimpleSummaryProvider="true" />
+            app:useSimpleSummaryProvider="true"
+            app:title="@string/proxy_password" />
         <SwitchPreference
             app:defaultValue="false"
             app:key="appendHttpProxy"

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -192,8 +192,8 @@
         <SwitchPreference
             app:defaultValue="true"
             app:key="enableMixed"
-            app:summary="@string/ENABLE_MIXED_sum"
-            app:title="@string/ENABLE_MIXED" />
+            app:summary="@string/enable_mixed_sum"
+            app:title="@string/enable_mixed" />
         <EditTextPreference
             app:icon="@drawable/ic_maps_directions_boat"
             app:key="mixedPort"

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -190,7 +190,7 @@
 
     <PreferenceCategory app:title="@string/inbound_settings">
         <SwitchPreference
-            app:defaultValue="false"
+            app:defaultValue="true"
             app:key="enableMixed"
             app:summary="@string/ENABLE_MIXED_sum"
             app:title="@string/ENABLE_MIXED" />

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -214,6 +214,11 @@
             app:key="allowAccess"
             app:summary="@string/allow_access_sum"
             app:title="@string/allow_access" />
+        <SwitchPreference
+            app:defaultValue="false"
+            app:key="disableMixed"
+            app:summary="@string/disable_mixed_sum"
+            app:title="@string/disable_mixed" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/cag_misc">

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -189,6 +189,11 @@
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/inbound_settings">
+        <SwitchPreference
+            app:defaultValue="false"
+            app:key="enableMixed"
+            app:summary="@string/ENABLE_MIXED_sum"
+            app:title="@string/ENABLE_MIXED" />
         <EditTextPreference
             app:icon="@drawable/ic_maps_directions_boat"
             app:key="mixedPort"
@@ -214,11 +219,6 @@
             app:key="allowAccess"
             app:summary="@string/allow_access_sum"
             app:title="@string/allow_access" />
-        <SwitchPreference
-            app:defaultValue="false"
-            app:key="disableMixed"
-            app:summary="@string/disable_mixed_sum"
-            app:title="@string/disable_mixed" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/cag_misc">


### PR DESCRIPTION
The first part of this PR extends PRs #1154 and #1158

To improve security and to simplify configurations a toggle control has been added to disable or enable socks5 mixed-in proxy at once. With it there's no more need to create socks5-specific routes or add custom JSON rules to prevent IP leaks, you just have to toggle it off, and there will be no more mixed-in inbound, no matter is it password-protected or not.

Active socks5 controls and mixed-in inbounds:

<img width="360" height="865" alt="Контролы активные" src="https://github.com/user-attachments/assets/95674608-9613-4482-b675-27bad6f32d20" />
<img width="360" height="841" alt="Инбаунды с mixed-in" src="https://github.com/user-attachments/assets/4157001f-3339-4d62-9615-c13c76afb72f" />

Disabled socks5 controls and removed socks5 mixed-in proxy:

<img width="360" height="881" alt="Контролы неактивные" src="https://github.com/user-attachments/assets/974f71bc-7ebd-4f6d-82cd-528da95c2ff4" />
<img width="360" height="408" alt="Инбаунды без mixed-in" src="https://github.com/user-attachments/assets/afbf5075-944a-4db2-85ef-6dee6b4d9d7b" />

The second part adds password protection to socks5 outbounds like naive since they currently don't use any credentials and are extremely vulnerable to IP detection mechanisms.

Current naive auto-generated section without credentials and sample of ip detection:

<img width="360" height="213" alt="Исходный конфиг naive" src="https://github.com/user-attachments/assets/a0a0d0d8-9394-46aa-a9ae-9eeeca87152d" />
<img width="360" height="102" alt="Определение внешнего ip с naive" src="https://github.com/user-attachments/assets/c9c61be8-7d58-46f5-a5c0-07ad7ed9f300" />

Auto-generated naive sections with randomly generated credentials:

<img width="360" height="209" alt="Конфиг naive с кредами" src="https://github.com/user-attachments/assets/b57fd91a-5ed9-4890-86aa-7330a7ad9076" />
